### PR TITLE
Feat: add extract tools into mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,21 @@ LeetTools MCP server distinguishes itself from other web search MCP servers by i
   - `query` (string): web search query
   - `search_max_results` (number, optional): Maximum Search Results (default 1)
   - `search_iteration` (number, optional): Search Pagination (default 1)
+  - `knowledge_base_name` (string, optional): name of local knowledge base (default mcp_search)
 
 ### `knowledge_base_search`
 - Search for local knowledge base
 - **Inputs:**
   - `query` (string): search query for local knowledge base
-  - `knowledge_base_name` (string, optional): name of local knowledge base
+  - `knowledge_base_name` (string, optional): name of local knowledge base (default mcp_search)
+
+### `extract`
+- Extract information from a knowledge base based on a query.
+- **Inputs:**
+  - `query` (string): search query for local knowledge base
+  - `extract_pydantic` (string): the Pydantic model python file full path to use for extracting the data
+  - `knowledge_base_name` (string, optional): name of local knowledge base (default mcp_search)
+  - `days_limit` (number, optional): the number of days to search for (defaults to 30)
 
 ## Usage with 5ire (Recommended)
 1. Follow this [link](https://5ire.app/) to install 5ire MCP client.

--- a/examples/company.py
+++ b/examples/company.py
@@ -1,0 +1,6 @@
+
+class Company(BaseModel):
+    name: str
+    description: str
+    industry: str
+    main_product_or_service: str

--- a/index.js
+++ b/index.js
@@ -214,8 +214,8 @@ function runServer(repoDir) {
   }
   logInfo('Environment variables set', {
     LEET_HOME: process.env.LEET_HOME,
-    EDS_LLM_API_KEY: process.env.EDS_LLM_API_KEY,
-    UV_HTTP_TIMEOUT: 300
+    EDS_LLM_API_KEY: `${process.env.EDS_LLM_API_KEY.slice(0, 4)}...${process.env.EDS_LLM_API_KEY.slice(-4)}`,
+    UV_HTTP_TIMEOUT: 600
   });
   logInfo('Starting LeetTools MCP server...');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leettools/leettools-mcp-server",
-    "version": "1.0.11",
+    "version": "1.0.14",
     "description": "CLI for running the LeetTools MCP server (Python-based via uv)",
     "main": "index.js",
     "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "leettools>=1.0.17",
-    "mcp[cli]>=1.3.0",
+    "mcp>=1.3.0",
     "torch==2.2.2",
 ]
 

--- a/src/leettools_mcp/command_options.py
+++ b/src/leettools_mcp/command_options.py
@@ -2,6 +2,7 @@ from typing import Optional, Callable, Dict, Any
 from pydantic import BaseModel
 
 from leettools_mcp.constants import Instructions
+from leettools_mcp.tools import Tools
 
 class CommandOptions(BaseModel):
     """Options for command execution"""
@@ -14,6 +15,84 @@ class CommandOptions(BaseModel):
     no_stdout_return: bool = True
     no_stderr_return: bool = True
     stdout_processor: Optional[Callable[[str], Dict[str, Any]]] = None
+
+    @staticmethod
+    def get_command_options(tool_type: str, knowledge_base_name: str = None) -> 'CommandOptions':
+        """
+        Get command options based on the tool type.
+        
+        Args:
+            tool_type: The type of tool (from Tools enum)
+            knowledge_base_name: Optional knowledge base name for relevant operations
+            
+        Returns:
+            CommandOptions configured for the specific tool type
+        """
+        from leettools_mcp.constants import FilePrefixes, ErrorCodes
+
+        if tool_type == Tools.KB_SEARCH:
+            return CommandOptions(
+                output_prefix=f"{FilePrefixes.KB_SEARCH}_{knowledge_base_name}",
+                error_code=ErrorCodes.KB_SEARCH_FAILED,
+                instructins="".join(Instructions.SEARCH_CITATIONS),
+                no_results_message="No knowledge base results found",
+                no_results_code=ErrorCodes.NO_KB_RESULTS,
+                read_output_file=True
+            )
+        
+        elif tool_type == Tools.WEB_SEARCH:
+            return CommandOptions(
+                output_prefix=f"{FilePrefixes.WEB_SEARCH}_{knowledge_base_name}",
+                error_code=ErrorCodes.WEB_SEARCH_FAILED,
+                instructins="".join(Instructions.SEARCH_CITATIONS),
+                no_results_message="No web search results found",
+                no_results_code=ErrorCodes.NO_WEB_SEARCH_RESULTS,
+                read_output_file=True
+            )
+        
+        elif tool_type == Tools.LIST_KB:
+            def process_list_kb_stdout(stdout: str) -> Dict[str, Any]:
+                """Process stdout from list_kb command to extract KB information"""
+                kb_lines = []
+                for line in stdout.splitlines():
+                    if line.startswith("Org:"):
+                        kb_lines.append(line)
+                
+                result = {
+                    "content": "\n".join(kb_lines) if kb_lines else "No knowledge bases found."
+                }
+                return result
+            
+            return CommandOptions(
+                output_prefix=f"{FilePrefixes.KB_OPS}_list_kb",
+                error_code=ErrorCodes.KB_OPERATION_FAILED,
+                read_output_file=False,
+                no_stdout_return=False,
+                no_stderr_return=True,
+                stdout_processor=process_list_kb_stdout
+            )
+        
+        elif tool_type in [Tools.CREATE_KB, Tools.ADD_LOCAL_TO_KB]:
+            operation = "create_kb" if tool_type == Tools.CREATE_KB else "add_local_to_kb"
+            return CommandOptions(
+                output_prefix=f"{FilePrefixes.KB_OPS}_{operation}",
+                error_code=ErrorCodes.KB_OPERATION_FAILED,
+                read_output_file=False,
+                no_stdout_return=True,
+                no_stderr_return=True
+            )
+        
+        elif tool_type == Tools.EXTRACT:
+            return CommandOptions(
+                output_prefix=f"{FilePrefixes.KB_OPS}_extract_{knowledge_base_name}",
+                error_code=ErrorCodes.KB_OPERATION_FAILED,
+                read_output_file=True,
+                no_stdout_return=True,
+                no_stderr_return=True
+            )
+        
+        else:
+            raise ValueError(f"Unknown tool type: {tool_type}")
 
     @staticmethod
     def for_kb_search(kb_name: str) -> 'CommandOptions':
@@ -79,3 +158,15 @@ class CommandOptions(BaseModel):
             stdout_processor=process_list_kb_stdout
         )
 
+    @staticmethod
+    def for_extract(kb_name: str) -> 'CommandOptions':
+        """Create options for extract operation"""
+        from leettools_mcp.constants import FilePrefixes, ErrorCodes
+        return CommandOptions(
+            output_prefix=f"{FilePrefixes.KB_OPS}_extract_{kb_name}",
+            error_code=ErrorCodes.KB_OPERATION_FAILED,
+            instructins="".join(Instructions.EXTRACT_INSTRUCTIONS),
+            read_output_file=True,
+            no_stdout_return=True,
+            no_stderr_return=True
+        )

--- a/src/leettools_mcp/constants.py
+++ b/src/leettools_mcp/constants.py
@@ -70,3 +70,7 @@ class Instructions:
         "For references, only show relevant links for articles. Don't show links for images. ",
         "If the full web link is not available, then don't show that reference.",
     ]
+    EXTRACT_INSTRUCTIONS = [
+        "The `content` field is a csv format for the extracted data. ",
+        "You should either show it as a table or save the content to a csv file. "
+    ]

--- a/src/leettools_mcp/server.py
+++ b/src/leettools_mcp/server.py
@@ -36,103 +36,106 @@ logger = logging.getLogger(MCP_SERVER_NAME)
 mcp = FastMCP(MCP_SERVER_NAME)
 
 
+async def _handle_command_failure(operation_type: str, result, options: CommandOptions) -> str:
+    """Handle command execution failure."""
+    error_msg = result.stderr or "Unknown error"
+    logger.error(f"{operation_type} operation failed: {error_msg}")
+    error = CommandError(
+        message=f"Error running {operation_type}",
+        details=error_msg,
+        code=options.error_code or f"{operation_type.upper()}_FAILED",
+    )
+    return error.model_dump_json(indent=2)
+
+async def _process_output_file(operation_type: str, output_path: str, options: CommandOptions) -> str:
+    """Process the output file and handle content."""
+    content = ""
+    if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
+        with open(output_path, "r") as f:
+            content = f.read()
+        logger.info(f"Read {len(content)} bytes from output file: {output_path}")
+    else:
+        logger.warning(f"Output file empty or missing: {output_path}")
+
+    if not content and options.no_results_message:
+        error = CommandError(
+            message=options.no_results_message,
+            details=f"The {operation_type} operation did not produce any content.",
+            code=options.no_results_code or f"NO_{operation_type.upper()}_RESULTS",
+        )
+        return error.model_dump_json(indent=2)
+
+    # Check if debug logging is enabled
+    context_length = os.environ.get(EnvironmentVars.CONTEXT_LENGTH)
+    if context_length is not None:
+        logger.info(f"Context length is defined: {context_length}, truncating content")
+        content = content[:int(context_length)]
+
+    return content
+
+async def _process_stdout(operation_type: str, result, options: CommandOptions) -> None:
+    """Process stdout using the tool-specific processor if available."""
+    if options.stdout_processor and result.stdout:
+        try:
+            processed_result = options.stdout_processor(result.stdout)
+            for key, value in processed_result.items():
+                setattr(result, key, value)
+            logger.info(f"Processed stdout for {operation_type}")
+        except Exception as e:
+            logger.error(f"Error processing stdout: {str(e)}")
+
 async def perform_operation(
-    operation_type: str, args: List[str], options: CommandOptions
+    operation_type: str,
+    args: List[str],
+    knowledge_base_name: str = None,
 ) -> str:
     """
     Common operation handler for all LeetTools operations.
 
     Args:
-        operation_type: Type of operation (for logging)
+        operation_type: Type of operation (from Tools enum)
         args: Command line arguments to pass to leet
-        options: CommandOptions object with execution options
+        knowledge_base_name: Optional knowledge base name for relevant operations
 
     Returns:
         JSON string with the operation results
     """
     try:
         logger.info(f"Performing {operation_type} operation")
+        options = CommandOptions.get_command_options(operation_type, knowledge_base_name)
 
-        # Create the output file paths
+        # Setup output paths and command arguments
         output_path, log_path = get_output_filepath(options.output_prefix)
         logger.info(f"Will save output to: {output_path}")
         logger.info(f"Will save logs to: {log_path}")
 
-        # Add output path to arguments if we're going to read it
         cmd_args = args.copy()
         if options.read_output_file:
             cmd_args.extend(["-o", output_path])
 
-        # Run the command
+        # Execute command
         result = await run_leet_command(cmd_args, log_path)
-
-        # Handle command failure
         if not result.success:
-            error_msg = result.stderr or "Unknown error"
-            logger.error(f"{operation_type} operation failed: {error_msg}")
-            error = CommandError(
-                message=f"Error running {operation_type}",
-                details=error_msg,
-                code=options.error_code or f"{operation_type.upper()}_FAILED",
-            )
-            return error.model_dump_json(indent=2)
+            return await _handle_command_failure(operation_type, result, options)
 
-        # If we need to read the output file
+        # Process output file if needed
         if options.read_output_file:
-            content = ""
-            if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
-                with open(output_path, "r") as f:
-                    content = f.read()
-                logger.info(
-                    f"Read {len(content)} bytes from output file: {output_path}"
-                )
-            else:
-                logger.warning(f"Output file empty or missing: {output_path}")
-
-            # Check if we have any content
-            if not content and options.no_results_message:
-                error = CommandError(
-                    message=options.no_results_message,
-                    details=f"The {operation_type} operation did not produce any content.",
-                    code=options.no_results_code
-                    or f"NO_{operation_type.upper()}_RESULTS",
-                )
-                return error.model_dump_json(indent=2)
-
-            # Check if debug logging is enabled
-            context_length = os.environ.get(EnvironmentVars.CONTEXT_LENGTH)
-            if context_length is not None:
-                logger.info(f"Context length is defined: {context_length}, truncating content")
-                content = content[:int(context_length)]
-
-            # Update the result with content from the output file
+            content = await _process_output_file(operation_type, output_path, options)
+            if isinstance(content, str) and content.startswith('{'): # Check if it's an error JSON
+                return content
             result.content = content
-
-            # Add instructions to the result if available
             if options.instructins:
                 result.instructions = options.instructins
 
-        # Process stdout if needed using the tool-specific processor
-        if options.stdout_processor and result.stdout:
-            try:
-                # Apply the tool-specific stdout processor
-                processed_result = options.stdout_processor(result.stdout)
+        # Process stdout if needed
+        await _process_stdout(operation_type, result, options)
 
-                # Update the result object with processed fields
-                for key, value in processed_result.items():
-                    setattr(result, key, value)
-
-                logger.info(f"Processed stdout for {operation_type}")
-            except Exception as e:
-                logger.error(f"Error processing stdout: {str(e)}")
-
-        # remove stdout and stderr from the result if not required
+        # Clean up result
         if options.no_stdout_return:
             result.stdout = None
         if options.no_stderr_return:
             result.stderr = None
 
-        # Convert result to JSON string
         return result.model_dump_json()
 
     except Exception as e:
@@ -188,7 +191,7 @@ async def add_local_to_kb(
             "-l",
             CommandArgs.LOG_LEVEL_DEBUG
         ],
-        options=CommandOptions.for_kb_operation("add_local_to_kb"),
+        knowledge_base_name=knowledge_base_name,
     )
 
 
@@ -205,7 +208,7 @@ async def create_kb(
     return await perform_operation(
         operation_type=Tools.CREATE_KB,
         args=["kb", "create", "-k", knowledge_base_name],
-        options=CommandOptions.for_kb_operation("create_kb"),
+        knowledge_base_name=knowledge_base_name,
     )
 
 
@@ -220,7 +223,7 @@ async def list_kb() -> str:
     return await perform_operation(
         operation_type=Tools.LIST_KB,
         args=["kb", "list"],
-        options=CommandOptions.for_list_kb(),
+        knowledge_base_name=None,
     )
 
 
@@ -229,6 +232,7 @@ async def web_search(
     query: str,
     search_max_results: int = 10,
     search_iteration: int = 1,
+    knowledge_base_name: str = CommandArgs.DEFAULT_KB_NAME,
 ) -> str:
     """
     Search the web for information on a topic using LeetTools.
@@ -237,6 +241,7 @@ async def web_search(
         query: the search query.
         search_max_results: maximum search results to process (default: 10).
         search_iteration: number of search iterations to perform (default: 1).
+        knowledge_base_name: name of the knowledge base to search (defaults to mcp_search).
     """
     return await perform_operation(
         operation_type=Tools.WEB_SEARCH,
@@ -253,7 +258,7 @@ async def web_search(
             "-p",
             f"search_iteration={search_iteration}",
         ],
-        options=CommandOptions.for_web_search(CommandArgs.DEFAULT_KB_NAME),
+        knowledge_base_name=knowledge_base_name,
     )
 
 
@@ -282,9 +287,45 @@ async def kb_search(
             "-p",
             "retriever_type=local",
         ],
-        options=CommandOptions.for_kb_search(knowledge_base_name),
+        knowledge_base_name=knowledge_base_name,
     )
 
+
+@mcp.tool()
+async def extract(
+    query: str,
+    extract_pydantic: str,
+    knowledge_base_name: str = CommandArgs.DEFAULT_KB_NAME,
+    days_limit: int = 30,
+) -> str:
+    """
+    Extract information from a knowledge base based on a query and a time limit.
+
+    Args:
+        query: the search query to extract relevant data.
+        extract_pydantic: the Pydantic model python file full path to use for extracting the data.
+        knowledge_base_name: name of the knowledge base to search (defaults to mcp_search).
+        days_limit: the number of days to search for (defaults to 30).
+    """
+    return await perform_operation(
+        operation_type=Tools.EXTRACT,
+        args=[
+            "flow",
+            "-t",
+            "extract",
+            "-k",   
+            knowledge_base_name,
+            "-q",
+            query,
+            "-p",
+            f"extract_pydantic={extract_pydantic}",
+            "-p",
+            f"days_limit={days_limit}",
+            "-p",
+            "extract_output_format=csv",
+        ],
+        knowledge_base_name=knowledge_base_name,
+    )
 
 def main():
     """Main entry point for running the LeetTools MCP server."""

--- a/src/leettools_mcp/tools.py
+++ b/src/leettools_mcp/tools.py
@@ -12,3 +12,4 @@ class Tools(str, Enum):
     CREATE_KB = "create_kb"
     ADD_LOCAL_TO_KB = "add_local_to_kb"
     DIGEST = "digest"
+    EXTRACT = "extract"

--- a/uv.lock
+++ b/uv.lock
@@ -1052,14 +1052,14 @@ version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "leettools" },
-    { name = "mcp", extra = ["cli"] },
+    { name = "mcp" },
     { name = "torch" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "leettools", specifier = ">=1.0.17" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.3.0" },
+    { name = "mcp", specifier = ">=1.3.0" },
     { name = "torch", specifier = "==2.2.2" },
 ]
 
@@ -1233,12 +1233,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/9d/ac1aaa3de8655a72fe07c0c2901ed35f0da2b3ffb2a1bfc4f46bbd7b6710/mcp-1.4.0.tar.gz", hash = "sha256:5b750b14ca178eeb7b2addbd94adb21785d7b4de5d5f3577ae193d787869e2dd", size = 155809 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/05/1cbc9f93900d4348f4e782811f251541d860e7d13c30cd68b402cd9edbd4/mcp-1.4.0-py3-none-any.whl", hash = "sha256:d2760e1ea7635b1e70da516698620a016cde214976416dd894f228600b08984c", size = 73036 },
-]
-
-[package.optional-dependencies]
-cli = [
-    { name = "python-dotenv" },
-    { name = "typer" },
 ]
 
 [[package]]


### PR DESCRIPTION
Major changes:
1. Add leettools extract workflow as one of the MCP tools.
2. Check the latest Hash for the GitHub when starting the MCP server so that it will automatically update the Python code.
3. Enforce venv to be built on Python 3.12.0.
4. Refactoring the Python MCP server code.
5. Redacting API Keys in the logging.